### PR TITLE
Add expiration to cache entry

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Gatekeeper"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.38.0"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.44.0"),
     ],
     targets: [
         .target(

--- a/Sources/Gatekeeper/Gatekeeper+Vapor/Request+Gatekeeper.swift
+++ b/Sources/Gatekeeper/Gatekeeper+Vapor/Request+Gatekeeper.swift
@@ -1,6 +1,6 @@
 import Vapor
 
-extension Request {
+public extension Request {
     func gatekeeper(
         config: GatekeeperConfig? = nil,
         cache: Cache? = nil,

--- a/Sources/Gatekeeper/Gatekeeper.swift
+++ b/Sources/Gatekeeper/Gatekeeper.swift
@@ -24,18 +24,14 @@ public struct Gatekeeper {
                         else: error
                     )
                     .map(updateEntry)
-                    .flatMap { entry -> EventLoopFuture<Entry> in
+                    .flatMap { entry in
                         // The amount of time the entry has existed.
                         let entryLifetime = Int(Date().timeIntervalSince1970 - entry.createdAt.timeIntervalSince1970)
                         // Remaining time until the entry expires. The entry would be expired by cache if it was negative.
                         let timeRemaining = Int(config.refreshInterval) - entryLifetime
-                        
-                        return cache
-                            .set(cacheKey, to: entry, expiresIn: .seconds(timeRemaining))
-                            .transform(to: entry)
+                        return cache.set(cacheKey, to: entry, expiresIn: .seconds(timeRemaining))
                     }
             }
-            .transform(to: ())
     }
     
     private func updateEntry(_ entry: Entry) -> Entry {

--- a/Sources/Gatekeeper/Gatekeeper.swift
+++ b/Sources/Gatekeeper/Gatekeeper.swift
@@ -11,29 +11,35 @@ public struct Gatekeeper {
         self.keyMaker = identifier
     }
     
-    public func gatekeep(on req: Request) -> EventLoopFuture<Void> {
+    public func gatekeep(
+        on req: Request,
+        throwing error: Error = Abort(.tooManyRequests, reason: "Slow down. You sent too many requests.")
+    ) -> EventLoopFuture<Void> {
         keyMaker
             .make(for: req)
             .flatMap { cacheKey in
                 fetchOrCreateEntry(for: cacheKey, on: req)
+                    .guard(
+                        { $0.requestsLeft > 0 },
+                        else: error
+                    )
                     .map(updateEntry)
-                    .flatMap { entry in
-                        cache
-                            .set(cacheKey, to: entry)
+                    .flatMap { entry -> EventLoopFuture<Entry> in
+                        // The amount of time the entry has existed.
+                        let entryLifetime = Int(Date().timeIntervalSince1970 - entry.createdAt.timeIntervalSince1970)
+                        // Remaining time until the entry expires. The entry would be expired by cache if it was negative.
+                        let timeRemaining = Int(config.refreshInterval) - entryLifetime
+                        
+                        return cache
+                            .set(cacheKey, to: entry, expiresIn: .seconds(timeRemaining))
                             .transform(to: entry)
                     }
             }
-            .guard(
-                { $0.requestsLeft > 0 },
-                else: Abort(.tooManyRequests, reason: "Slow down. You sent too many requests."))
             .transform(to: ())
     }
     
     private func updateEntry(_ entry: Entry) -> Entry {
         var newEntry = entry
-        if newEntry.hasExpired(within: config.refreshInterval) {
-            newEntry.reset(remainingRequests: config.limit)
-        }
         newEntry.touch()
         return newEntry
     }

--- a/Sources/Gatekeeper/GatekeeperEntry.swift
+++ b/Sources/Gatekeeper/GatekeeperEntry.swift
@@ -14,12 +14,11 @@ extension Gatekeeper.Entry {
         Date().timeIntervalSince1970 - createdAt.timeIntervalSince1970 >= interval
     }
     
-    mutating func reset(remainingRequests: Int) {
-        createdAt = Date()
-        requestsLeft = remainingRequests
-    }
-    
     mutating func touch() {
-        requestsLeft -= 1
+        if requestsLeft > 0 {
+            requestsLeft -= 1
+        } else {
+            requestsLeft = 0
+        }
     }
 }

--- a/Sources/Gatekeeper/GatekeeperMiddleware.swift
+++ b/Sources/Gatekeeper/GatekeeperMiddleware.swift
@@ -3,16 +3,31 @@ import Vapor
 /// Middleware used to rate-limit a single route or a group of routes.
 public struct GatekeeperMiddleware: Middleware {
     private let config: GatekeeperConfig?
+    private let keyMaker: GatekeeperKeyMaker?
+    private let error: Error?
     
-    /// Initialize with a custom `GatekeeperConfig` instead of using the default `app.gatekeeper.config`
-    public init(config: GatekeeperConfig? = nil) {
+    /// Initialize a new middleware for rate-limiting routes, by optionally overriding default configurations.
+    ///
+    /// - Parameters:
+    ///     - config: Override `GatekeeperConfig` instead of using the default `app.gatekeeper.config`
+    ///     - keyMaker: Override `GatekeeperKeyMaker` instead of using the default `app.gatekeeper.keyMaker`
+    ///     - config: Override the `Error` thrown when the user is rate-limited instead of using the default error.
+    public init(config: GatekeeperConfig? = nil, keyMaker: GatekeeperKeyMaker? = nil, error: Error? = nil) {
         self.config = config
+        self.keyMaker = keyMaker
+        self.error = error
     }
     
     public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
-        request
-            .gatekeeper(config: config)
-            .gatekeep(on: request)
-            .flatMap { next.respond(to: request) }
+        let gatekeeper = request.gatekeeper(config: config, keyMaker: keyMaker)
+            
+        let gatekeep: EventLoopFuture<Void>
+        if let error = error {
+            gatekeep = gatekeeper.gatekeep(on: request, throwing: error)
+        } else {
+            gatekeep = gatekeeper.gatekeep(on: request)
+        }
+        
+        return gatekeep.flatMap { next.respond(to: request) }
     }
 }


### PR DESCRIPTION
* Adds expiration functionality recently added to the Vapor `Cache` to prevent the cache being filled up with stale values, such as old rate-limiting keys.
* Allows customization of the error thrown if they client is sending too many requests:
```swift
req.gatekeeper.gatekeeper(on: req, throwing: MyError())
```
```swift
GatekeeperMiddleware(error: MyError())
```
* Fixes an issue where effectively even if the config was 5 requests per second, the client would only really have 4 request available and be rate-limited on the 5th. They are now correctly first rate-limited on request no. 6.