### PR TITLE
Adds hostname extraction for ‘forwarded’ header

### DIFF
--- a/Sources/Gatekeeper/Request+Hostname.swift
+++ b/Sources/Gatekeeper/Request+Hostname.swift
@@ -2,6 +2,6 @@ import Vapor
 
 extension Request {
     var hostname: String? {
-        headers.first(name: .xForwardedFor) ?? remoteAddress?.hostname
+        headers.forwarded.first?.for ?? headers.first(name: .xForwardedFor) ?? remoteAddress?.hostname
     }
 }


### PR DESCRIPTION
The previous implementation extracted a hostname from the `X-Forwarded-For` header. this adds additional support for the standardized [Forwarded header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded).

This also improves testing support when using Vapor's [headers.forwarded](https://github.com/vapor/vapor/blob/main/Sources/Vapor/HTTP/Headers/HTTPHeaders%2BForwarded.swift).